### PR TITLE
Feature/travis change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 
 install:
   ## install as binaries what we can get as binaries
-  - ./run.sh install_aptget r-cran-data.table r-cran-dplyr r-cran-ggmap r-cran-ggplot2 r-cran-lazyeval r-cran-lubridate r-cran-maps r-cran-purr r-cran-rcolorbrewer r-cran-stringr r-cran-tidyr r-cran-knitr r-cran-pander r-cran-rmarkdown
+  - ./run.sh install_aptget r-cran-data.table r-cran-dplyr r-cran-ggmap r-cran-ggplot2 r-cran-lazyeval r-cran-lubridate r-cran-maps r-cran-purrr r-cran-rcolorbrewer r-cran-stringr r-cran-tidyr r-cran-knitr r-cran-pander r-cran-rmarkdown
   ## install as R packages what we (currently) cannot get as binaries
   - ./run.sh install_r hurricaneexposuredata weathermetrics
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,37 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
 
-language: R
-warnings_are_errors: false
+language: c
 
-r_github_packages:
-  - cran/survival
-  - geanders/hurricaneexposuredata
+sudo: required
+
+## use 'trusty' which is old (14.04) but not as jurassic as the default of 'precise' (12.04)
+dist: trusty
+
+env:
+  global:
+    ## declare the 'geanders' drat repo
+    - DRAT_REPOS=geanders
+
+before_install:
+  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
+  - ./run.sh bootstrap
+
+install:
+  ## install as binaries what we can get as binaries
+  - ./run.sh install_aptget r-cran-data.table r-cran-dplyr r-cran-ggmap r-cran-ggplot2 r-cran-lazyeval r-cran-lubridate r-cran-maps r-cran-purr r-cran-rcolorbrewer r-cran-stringr r-cran-tidyr r-cran-knitr r-cran-pander r-cran-rmarkdown
+  ## install as R packages what we (currently) cannot get as binaries
+  - ./run.sh install_r hurricaneexposuredata weathermetrics
+
+script:
+  - ./run.sh run_tests
+
+after_failure:
+  - ./run.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+    
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,8 +42,6 @@ Imports:
     maps (>= 3.1.1),
     purrr (>= 0.2.2),
     RColorBrewer (>= 1.1.2),
-    splines,
-    stats,
     stringr (>= 1.1.0),
     tidyr (>= 0.6.0)
 RoxygenNote: 6.0.0


### PR DESCRIPTION
Noticed that Travis was failing so I quickly launched a trial balloon ... using my very explicit Travis setup.

I don't claim it is for everybody, but it suits me quite well, and you are such a smart coder that you will be able to read each line.   In essence, we fall back to the 'old' Travis so that we get `sudo` so that we can take advantage of Michael Rutter's excellent (but little known) Ubuntu repos with about 3400 binary CRAN packages.   And we install what we need.

I also played cute and used a drat integration feature (hah!!) that I am not sure I ever tried. Setting `DRAT_REPOS=geanders` uses the logic we discuss in the paper and adds your drat repo.  This promply revealed a bug: I was still using http when github now requires https.  Fixed.

At the every end we then install two packages are R packages for which Michael has not binaries: the data package, and weathermetrics.  And then Travis goes to work and tests.  All good.

So this builds now.  We could even be cute and add a matrix of with/without the data package.  But that's for another day.  Pour yourself a hot or cold one and see if you like, or hate, the new .travis.yml.